### PR TITLE
1.4.1 Dev Release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - '14.17.0'
+  - '18.17.0'

--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ class WebpackJSXExport {
         : this.defaultComment;
 
       // Glob gather (reguardless if its a direct path to JSX file)
-      glob.sync(input).forEach((file) => {
+      glob.sync(input.replaceAll(path.sep, path.posix.sep)).forEach((file) => {
         // Only .jsx files please
         if (path.basename(file).indexOf('.jsx') !== -1) {
           // Build up our file information object for export processing

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "webpack jsx static export",
     "webpack jsx static render export"
   ],
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Plugin to allow for the static rendering and exporting of JSX files to disk",
   "repository": "drolsen/webpack-jsx-export",
   "bugs": {

--- a/test/glob/glob.test.config.js
+++ b/test/glob/glob.test.config.js
@@ -16,7 +16,7 @@ module.exports = (env, argv) => {
   config.plugins = [
     new WebpackJSXExport({
       files: [{
-        input: './test/glob/*.jsx',
+        input: path.resolve(__dirname, './*.jsx'),
         output: './dist/glob/'
       }]
     })


### PR DESCRIPTION
- Glob fix by setting file.input paths to use path.posix.sep which ensures that paths using path.resolve on windows will still work.
- Updates glob test to define file.input by means of relative path ran through path.resolve like real world scenarios.
- Bumps .travis.yml version number up to node 18.17.0 and package.json version up 1.4.1